### PR TITLE
Fix: bad argument to UnitName (Secret values are only allowed during untainted execution)

### DIFF
--- a/UI/Widgets/Tooltips.lua
+++ b/UI/Widgets/Tooltips.lua
@@ -614,7 +614,7 @@ end
 
 local function handleNpcTooltip(tooltip)
   if not tooltip or tooltip:IsForbidden() then return end
-  local _, unit = tooltip:GetUnit()
+  local _, unit = tooltip:GetUnit(); if not unit or (issecretvalue and issecretvalue(unit)) then return end
   if not canAccess(unit) then return end
   local ok, exists = pcall(UnitExists, unit)
   if not ok or not exists then return end


### PR DESCRIPTION
This PR fixes a LUA error in WoW 11.0 (The War Within) where `tooltip:GetUnit()` returns a secret/tainted value that causes a crash when accessed without a check. Added `issecretvalue(unit)` check before processing.